### PR TITLE
Create workflow to automatically build the game

### DIFF
--- a/.github/workflows/activation.yml
+++ b/.github/workflows/activation.yml
@@ -1,0 +1,17 @@
+name: Acquire activation file
+on: [push]
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: webbertakken/unity-request-manual-activation-file@v2.0-alpha-1
+        with:
+          unityVersion: 2020.2.0f1
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,9 @@ jobs:
           unityVersion: 2020.2.0f1
           targetPlatform: Android
           versioning: Semantic
+      - name: Rename APK
+        run: cp build/Android/Android.apk "build/Android/Project SCP v${{ steps.unityBuild.outputs.buildVersion }}.apk"
       - uses: actions/upload-artifact@v1
         with:
           name: ${{ env.PROJECT_NAME }} ${{ steps.unityBuild.outputs.buildVersion }} Android
-          path: build/Android
+          path: build/Android/Project SCP v${{ steps.unityBuild.outputs.buildVersion }}.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: '🔧 Build Project'
+
+on:
+  pull_request: {}
+  push: { branches: [main] }
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  PROJECT_NAME: Project SCP
+
+jobs:
+  buildForAndroid:
+    name: Unity 2020.2.0f1 - Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions/cache@v1.1.0
+        with:
+          path: ./Library
+          key: Library-Cache-Android
+          restore-keys: |
+            Library-
+      - uses: webbertakken/unity-builder@v2.0-alpha-6
+        id: unityBuild
+        with:
+          projectPath: .
+          unityVersion: 2020.2.0f1
+          targetPlatform: Android
+          versioning: Semantic
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ env.PROJECT_NAME }} ${{ steps.unityBuild.outputs.buildVersion }} Android
+          path: build/Android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           targetPlatform: Android
           versioning: Semantic
       - name: Rename APK
-        run: cp build/Android/Android.apk "build/Android/Project SCP v${{ steps.unityBuild.outputs.buildVersion }}.apk"
+        run: sudo cp build/Android/Android.apk "build/Android/Project SCP v${{ steps.unityBuild.outputs.buildVersion }}.apk"
       - uses: actions/upload-artifact@v1
         with:
           name: ${{ env.PROJECT_NAME }} ${{ steps.unityBuild.outputs.buildVersion }} Android


### PR DESCRIPTION
The activation workflow generates the manual activation file to get a license from unity.
The build workflow builds the project to desktop platforms.
The first build will probably take 1 hour but the next ones should be faster because of caching.
There should be a UNITY_LICENSE secret on the repo for the build to work. The secret must contain the contents of the .ulf unity license file.
After the activation workflow runs it generates an artifact containing a .alf file that should be uploaded at the [unity site](https://license.unity3d.com/manual) to generate the .ulf file.

Documentation for the activation action [here](https://game.ci/docs/github/activation).
Documentation for the build action [here](https://game.ci/docs/github/builder).